### PR TITLE
fix(minio): improve security and compatibility of minio image with op…

### DIFF
--- a/images/minio/prod.yaml
+++ b/images/minio/prod.yaml
@@ -1,29 +1,60 @@
-include: images/apko.yaml
-
 contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
   packages:
     - coreutils
     - busybox
     - curl
 
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: nonroot
+
 paths:
+  - path: /home/nonroot
+    type: directory
+    permissions: 0o775
+    uid: 65532
+    gid: 65532
+  - path: /mnt
+    type: directory
+    permissions: 0o770
+    uid: 65532
+    gid: 0
   - path: /mnt/data
     type: directory
-    permissions: 0o777
+    permissions: 0o770
     uid: 65532
-    gid: 65532
+    gid: 0
   - path: /.mc
     type: directory
-    permissions: 0o777
+    permissions: 0o770
     uid: 65532
-    gid: 65532
+    gid: 0
+
+work-dir: /home/nonroot
 
 entrypoint:
   command: /usr/bin/minio
 
 cmd: server /mnt/data --console-address :9090 --address :9000
 
+archs:
+  - amd64
+  - arm64
+
 annotations:
+  org.opencontainers.image.licenses: 'MIT'
+  org.opencontainers.image.vendor: 'GitGuardian'
+  org.opencontainers.image.authors: 'GitGuardian SRE Team <sre@gitguardian.com>'
   org.opencontainers.image.title: 'MinIO'
   org.opencontainers.image.description: 'MinIO image based on Wolfi OS'
   org.opencontainers.image.source: 'https://github.com/GitGuardian/wolfi/tree/main/images/minio'


### PR DESCRIPTION
Improve overall security of MinIO image for OpenShift compatibility according to RedHat official documentation :
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.12/html/images/creating-images#use-uid_create-images

Here using `gid: 0` is recommended by RedHat to make image compatible with random UIDs

Allow deploying image without any modification to `podSecurityContext` and `containerSecurityContext` such as :
```yaml
podSecurityContext: {}
defaultBuckets: 'admin,chunks,ruler'
containerSecurityContext: {}
```
To be merged for `2025.10` ?