### PR TITLE
ENT-3237 remove src-fingerprint

### DIFF
--- a/images/python-gitguardian/prod.yaml
+++ b/images/python-gitguardian/prod.yaml
@@ -14,7 +14,6 @@ contents:
     - libpq-16
     - pango
     - ripgrep
-    - src-fingerprint
     - tini
     - wolfi-baselayout
 


### PR DESCRIPTION
Package isn't used anymore in GIM, and is responsible for many CVEs