### PR TITLE
Add Wolfi-based Bun base image

### DIFF
--- a/.claude/skills/wolfi-base-image/SKILL.md
+++ b/.claude/skills/wolfi-base-image/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: wolfi-base-image
+description: Scaffolds a new Wolfi base image in the GitGuardian/wolfi repository. Use when creating a new container image, adding an image to wolfi, or when user says "new image" or "add image".
+---
+
+# Wolfi Base Image Scaffolding
+
+Creates all files for a new Wolfi-based container image following GitGuardian conventions.
+
+## Inputs to Gather
+
+Before generating files, confirm these with the user:
+
+1. **Image name** (lowercase, e.g. `bun`, `nginx`, `helm`)
+2. **Main package(s)** in Wolfi (e.g. `bun`, `nodejs`, `python-3.13`)
+3. **Entrypoint** command (e.g. `/usr/bin/bun`, `/usr/bin/node`)
+4. **Versions** to support (e.g. `["1.3"]`, `["3.13", "3.12"]`, or none)
+5. **Variants** needed: `prod` (always), `shell` (optional), `dev` (optional, requires shell)
+6. **Description** for OCI annotations (e.g. "Minimal Bun runtime image based on Wolfi")
+7. **Extra packages** for shell or dev variants (beyond the standard set)
+8. **CMD** (optional, e.g. `--help`, `--version`)
+
+## File Generation
+
+Generate files in this order. See [reference.md](reference.md) for full templates.
+
+### 1. Root-Level Image Configs
+
+**Always create `images/<name>/prod.yaml`:**
+
+```yaml
+include: images/apko.yaml
+
+contents:
+  packages:
+    - ca-certificates-bundle
+    - glibc-locale-posix
+    - <MAIN_PACKAGE>
+    - wolfi-baselayout
+
+entrypoint:
+  command: <ENTRYPOINT>
+
+cmd: <CMD>  # omit if not needed
+
+annotations:
+  org.opencontainers.image.title: '<name>'
+  org.opencontainers.image.description: '<DESCRIPTION>'
+  org.opencontainers.image.source: 'https://github.com/GitGuardian/wolfi/tree/main/images/<name>'
+```
+
+**If shell variant, create `images/<name>/shell.yaml`:**
+
+```yaml
+include: images/<name>/prod.yaml
+
+contents:
+  packages:
+    - bash
+    - busybox
+    - curl
+    - openssl
+    - wget
+```
+
+**If dev variant, create `images/<name>/dev.yaml`:**
+
+```yaml
+include: images/<name>/shell.yaml
+
+contents:
+  packages:
+    - apk-tools
+    - build-base
+    - gettext
+    - git
+    - vim
+    - wolfi-keys
+
+accounts:
+  run-as: root
+```
+
+### 2. Version Subdirectories
+
+For each version (e.g. `1.3`), create `images/<name>/<version>/` with the selected variants.
+
+**Versioned `prod.yaml`** pins the package:
+
+```yaml
+include: images/<name>/prod.yaml
+
+contents:
+  packages:
+    - <MAIN_PACKAGE>~<VERSION>
+```
+
+**Versioned `shell.yaml` and `dev.yaml`** just re-include the parent:
+
+```yaml
+include: images/<name>/shell.yaml
+```
+
+**`latest/` directory** files are simple re-includes with no version pin:
+
+```yaml
+include: images/<name>/prod.yaml
+```
+
+### 3. CI Workflow
+
+Create `.github/workflows/<name>.yaml`. The matrix strategy depends on variants and versions.
+
+**Key rules:**
+- Schedule: `"00 01 * * 1-5"` (weekdays at 01:00)
+- Path triggers: `.github/workflows/<name>.yaml` and `images/<name>/**/*.yaml`
+- Permissions: `contents: read`, `packages: write`, `attestations: write`, `id-token: write`, `security-events: write`, `actions: read`
+- Tag format: `{version}` for prod, `{version}-shell` for shell, `{version}-dev` for dev
+- Target format: `{version}/{variant}` when versions exist, `{variant}` when no versions
+
+See [reference.md](reference.md) for the full workflow template.
+
+### 4. README
+
+Create `images/<name>/README.md` with:
+- Title and one-line description
+- Versions table (all version/variant combinations)
+- Provenance verification (`gh attestation verify`)
+- Cosign signature verification
+- SBOM attestation verification and download
+
+See [reference.md](reference.md) for the full README template.
+
+### 5. Root README Update
+
+Add a row to the `Available Images` table in `README.md`, in **alphabetical order**:
+
+```
+| [<name>](./images/<name>/) | `docker pull ghcr.io/gitguardian/wolfi/<name>` |
+```
+
+## Checklist
+
+- [ ] `images/<name>/prod.yaml` with correct packages and annotations
+- [ ] `images/<name>/shell.yaml` (if shell variant)
+- [ ] `images/<name>/dev.yaml` (if dev variant)
+- [ ] Version subdirectories with pinned packages
+- [ ] `latest/` subdirectory with simple re-includes
+- [ ] `.github/workflows/<name>.yaml` with correct matrix
+- [ ] `images/<name>/README.md` with all verification sections
+- [ ] Root `README.md` updated with new entry in alphabetical order

--- a/.claude/skills/wolfi-base-image/reference.md
+++ b/.claude/skills/wolfi-base-image/reference.md
@@ -1,0 +1,274 @@
+# Wolfi Base Image Reference
+
+Complete templates for all generated files. Substitute placeholders:
+- `<NAME>` - image name (lowercase)
+- `<MAIN_PACKAGE>` - Wolfi package name
+- `<ENTRYPOINT>` - full path to entrypoint binary
+- `<DESCRIPTION>` - OCI image description
+- `<VERSION>` - version string (e.g. `1.3`, `3.13`)
+- `<VERSIONS_JSON>` - JSON array for matrix (e.g. `[latest, "1.3"]`)
+- `<VARIANTS_JSON>` - JSON array for matrix (e.g. `[prod, shell, dev]`)
+
+## Table of Contents
+
+1. [CI Workflow Template](#ci-workflow-template)
+2. [README Template](#readme-template)
+3. [Version Pinning Rules](#version-pinning-rules)
+4. [Advanced Patterns](#advanced-patterns)
+
+---
+
+## CI Workflow Template
+
+```yaml
+name: <NAME>
+
+on:
+  schedule:
+    - cron: "00 01 * * 1-5"
+  pull_request:
+    paths:
+      - .github/workflows/<NAME>.yaml
+      - 'images/<NAME>/*.yaml'
+      - 'images/<NAME>/**/*.yaml'
+  push:
+    branches:
+      - 'main'
+    paths:
+      - .github/workflows/<NAME>.yaml
+      - 'images/<NAME>/*.yaml'
+      - 'images/<NAME>/**/*.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+  security-events: write
+  actions: read
+
+jobs:
+  publish:
+    strategy:
+      matrix:
+        version: <VERSIONS_JSON>
+        variant: <VARIANTS_JSON>
+    name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || matrix.variant == 'dev' && '-dev' || '' }}
+    uses: './.github/workflows/release.yaml'
+    with:
+      tag: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || matrix.variant == 'dev' && '-dev' || '' }}
+      target: ${{ format('{0}/{1}', matrix.version, matrix.variant) }}
+    secrets: inherit
+```
+
+**When no version subdirectories exist** (single-version image), use:
+
+```yaml
+jobs:
+  publish:
+    strategy:
+      matrix:
+        version: [latest]
+        variant: <VARIANTS_JSON>
+    name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || matrix.variant == 'dev' && '-dev' || '' }}
+    uses: './.github/workflows/release.yaml'
+    with:
+      tag: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || matrix.variant == 'dev' && '-dev' || '' }}
+      target: ${{ matrix.variant }}
+    secrets: inherit
+```
+
+Note: `target` uses `matrix.variant` directly (no version prefix) when there are no version subdirectories.
+
+---
+
+## README Template
+
+```markdown
+# <NAME>
+
+<DESCRIPTION>
+
+## Versions
+
+| Version      | Pull URL                                         |
+| ------------ | ------------------------------------------------ |
+<!-- One row per version/variant combination, e.g.: -->
+| latest       | ghcr.io/gitguardian/wolfi/<NAME>:latest          |
+| latest-shell | ghcr.io/gitguardian/wolfi/<NAME>:latest-shell    |
+| latest-dev   | ghcr.io/gitguardian/wolfi/<NAME>:latest-dev      |
+| <VERSION>       | ghcr.io/gitguardian/wolfi/<NAME>:<VERSION>       |
+| <VERSION>-shell | ghcr.io/gitguardian/wolfi/<NAME>:<VERSION>-shell |
+| <VERSION>-dev   | ghcr.io/gitguardian/wolfi/<NAME>:<VERSION>-dev   |
+
+## Verify the Provenance
+
+GitHub CLI ([gh](https://cli.github.com/)) can be used to retrieve the build provenance, which details the exact commit, workflow, and runner that produced the image:
+
+- **Production image**
+
+\`\`\`shell
+gh attestation verify \
+  --owner gitguardian \
+  oci://ghcr.io/gitguardian/wolfi/<NAME>:latest
+\`\`\`
+
+- **Shell image**
+
+\`\`\`shell
+gh attestation verify \
+  --owner gitguardian \
+  oci://ghcr.io/gitguardian/wolfi/<NAME>:latest-shell
+\`\`\`
+
+## Image Verification
+
+All official images are **cryptographically signed** using [Sigstore Cosign](https://www.sigstore.dev/).
+
+### Verify the Image Signature
+
+To ensure the image is authentic and has not been tampered with, use the following command:
+
+- **Production image**
+
+\`\`\`shell
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/GitGuardian/wolfi/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/gitguardian/wolfi/<NAME>:latest | jq
+\`\`\`
+
+- **Shell image**
+
+\`\`\`shell
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/GitGuardian/wolfi/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/gitguardian/wolfi/<NAME>:latest-shell | jq
+\`\`\`
+
+### Image SBOMs
+
+To enhance transparency, we generate SBOMs for each release. SBOMs are available directly from the container registry
+and can be verified using using [Sigstore Cosign](https://www.sigstore.dev/).
+
+#### Verify the Image Attestations
+
+- **Production image**
+
+\`\`\`shell
+cosign verify-attestation \
+  --type=https://spdx.dev/Document \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/GitGuardian/wolfi/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/gitguardian/wolfi/<NAME>:latest
+\`\`\`
+
+- **Shell image**
+
+\`\`\`shell
+cosign verify-attestation \
+  --type=https://spdx.dev/Document \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/GitGuardian/wolfi/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/gitguardian/wolfi/<NAME>:latest-shell
+\`\`\`
+
+This will pull in the signature for the attestation specified by the --type parameter, which in this case is the SPDX attestation. You will receive output that verifies the SBOM attestation signature in cosign's transparency log:
+
+\`\`\`shell
+Verification for ghcr.io/gitguardian/wolfi/<NAME>:latest --
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - Existence of the claims in the transparency log was verified offline
+  - The code-signing certificate was verified using trusted certificate authority certificates
+Certificate subject: https://github.com/GitGuardian/wolfi/.github/workflows/release.yaml@refs/heads/main
+Certificate issuer URL: https://token.actions.githubusercontent.com
+GitHub Workflow Trigger: push
+GitHub Workflow SHA: ...
+GitHub Workflow Name: <NAME>
+GitHub Workflow Repository: GitGuardian/wolfi
+GitHub Workflow Ref: refs/heads/main
+...
+\`\`\`
+
+#### Download the Image SBOM Attestations
+
+To download an attestation, use the `cosign` download attestation command and provide both the predicate type and the build platform. For example, the following command will obtain the SBOM for the <NAME> image on `linux/amd64`:
+
+- **Production image**
+
+\`\`\`shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  ghcr.io/gitguardian/wolfi/<NAME>:latest | jq -r .payload | base64 -d | jq .predicate
+\`\`\`
+
+- **Shell image**
+
+\`\`\`shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  ghcr.io/gitguardian/wolfi/<NAME>:latest-shell | jq -r .payload | base64 -d | jq .predicate
+\`\`\`
+```
+
+---
+
+## Version Pinning Rules
+
+| Syntax | Meaning | Example |
+| --- | --- | --- |
+| `<pkg>` | Latest available | `bun` |
+| `<pkg>~X.Y` | Compatible release >= X.Y, < (X+1).0 | `bun~1.3` |
+| `<pkg>~X.Y.Z` | Exact patch pin >= X.Y.Z | `istio-envoy-1.25~1.25.2` |
+
+Some packages use version-suffixed names: `python-3.13`, `nodejs-22`. Check Wolfi package registry if unsure.
+
+---
+
+## Advanced Patterns
+
+### Custom User/Group
+
+Override in `prod.yaml` when the runtime needs a named user:
+
+```yaml
+accounts:
+  groups:
+    - groupname: <username>
+      gid: 65532
+  users:
+    - username: <username>
+      uid: 65532
+      gid: 65532
+  run-as: <username>
+
+work-dir: /home/<username>
+```
+
+### Custom Directories
+
+When the runtime needs writable paths:
+
+```yaml
+paths:
+  - path: /var/lib/<name>
+    type: directory
+    permissions: 0o755
+    uid: 65532
+    gid: 65532
+```
+
+### Dynamic Package Pinning via Workflow
+
+For images where version directories don't exist but you still want version-pinned builds, use the `packages` workflow input:
+
+```yaml
+with:
+  packages: >-
+    ${{ matrix.version != 'latest' && format('<pkg>~{0}', matrix.version) || '' }}
+```

--- a/.github/workflows/bun.yaml
+++ b/.github/workflows/bun.yaml
@@ -1,0 +1,39 @@
+name: bun
+
+on:
+  schedule:
+    - cron: "00 01 * * 1-5"
+  pull_request:
+    paths:
+      - .github/workflows/bun.yaml
+      - 'images/bun/*.yaml'
+      - 'images/bun/**/*.yaml'
+  push:
+    branches:
+      - 'main'
+    paths:
+      - .github/workflows/bun.yaml
+      - 'images/bun/*.yaml'
+      - 'images/bun/**/*.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+  security-events: write
+  actions: read
+
+jobs:
+  publish:
+    strategy:
+      matrix:
+        version: [latest, "1.3"]
+        variant: [prod, shell, dev]
+    name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || matrix.variant == 'dev' && '-dev' || '' }}
+    uses: './.github/workflows/release.yaml'
+    with:
+      tag: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || matrix.variant == 'dev' && '-dev' || '' }}
+      target: ${{ format('{0}/{1}', matrix.version, matrix.variant) }}
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 | -------------------------------------------------------------- | ---------------------------------------------------------------- |
 | [apache-tika](./images/apache-tika/)                           | `docker pull ghcr.io/gitguardian/wolfi/apache-tika`              |
 | [bash](./images/bash/)                                         | `docker pull ghcr.io/gitguardian/wolfi/bash`                     |
+| [bun](./images/bun/)                                           | `docker pull ghcr.io/gitguardian/wolfi/bun`                      |
 | [fluent-bit](./images/fluent-bit/)                             | `docker pull ghcr.io/gitguardian/wolfi/fluent-bit`               |
 | [ggshield](./images/ggshield/)                                 | `docker pull ghcr.io/gitguardian/wolfi/ggshield`                 |
 | [helm](./images/helm/)                                         | `docker pull ghcr.io/gitguardian/wolfi/helm`                     |

--- a/images/bun/1.3/dev.yaml
+++ b/images/bun/1.3/dev.yaml
@@ -1,0 +1,5 @@
+include: images/bun/dev.yaml
+
+contents:
+  packages:
+    - bun~1.3

--- a/images/bun/1.3/prod.yaml
+++ b/images/bun/1.3/prod.yaml
@@ -1,0 +1,5 @@
+include: images/bun/prod.yaml
+
+contents:
+  packages:
+    - bun~1.3

--- a/images/bun/1.3/shell.yaml
+++ b/images/bun/1.3/shell.yaml
@@ -1,0 +1,5 @@
+include: images/bun/shell.yaml
+
+contents:
+  packages:
+    - bun~1.3

--- a/images/bun/README.md
+++ b/images/bun/README.md
@@ -1,0 +1,127 @@
+# Bun
+
+Minimal Bun image based on Wolfi.
+
+## Versions
+
+| Version     | Pull URL                                    |
+| ----------- | ------------------------------------------- |
+| latest      | ghcr.io/gitguardian/wolfi/bun:latest        |
+| latest-shell | ghcr.io/gitguardian/wolfi/bun:latest-shell |
+| latest-dev  | ghcr.io/gitguardian/wolfi/bun:latest-dev    |
+| 1.3         | ghcr.io/gitguardian/wolfi/bun:1.3           |
+| 1.3-shell   | ghcr.io/gitguardian/wolfi/bun:1.3-shell     |
+| 1.3-dev     | ghcr.io/gitguardian/wolfi/bun:1.3-dev       |
+
+## Verify the Provenance
+
+GitHub CLI ([gh](https://cli.github.com/)) can be used to retrieve the build provenance, which details the exact commit, workflow, and runner that produced the image:
+
+- **Production image**
+
+```shell
+gh attestation verify \
+  --owner gitguardian \
+  oci://ghcr.io/gitguardian/wolfi/bun:latest
+```
+
+- **Shell image**
+
+```shell
+gh attestation verify \
+  --owner gitguardian \
+  oci://ghcr.io/gitguardian/wolfi/bun:latest-shell
+```
+
+## Image Verification
+
+All official images are **cryptographically signed** using [Sigstore Cosign](https://www.sigstore.dev/).
+
+### Verify the Image Signature
+
+To ensure the image is authentic and has not been tampered with, use the following command:
+
+- **Production image**
+
+```shell
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/GitGuardian/wolfi/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/gitguardian/wolfi/bun:latest | jq
+```
+
+- **Shell image**
+
+```shell
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/GitGuardian/wolfi/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/gitguardian/wolfi/bun:latest-shell | jq
+```
+
+### Image SBOMs
+
+To enhance transparency, we generate SBOMs for each release. SBOMs are available directly from the container registry
+and can be verified using using [Sigstore Cosign](https://www.sigstore.dev/).
+
+#### Verify the Image Attestations
+
+- **Production image**
+
+```shell
+cosign verify-attestation \
+  --type=https://spdx.dev/Document \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/GitGuardian/wolfi/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/gitguardian/wolfi/bun:latest
+```
+
+- **Shell image**
+
+```shell
+cosign verify-attestation \
+  --type=https://spdx.dev/Document \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/GitGuardian/wolfi/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/gitguardian/wolfi/bun:latest-shell
+```
+
+This will pull in the signature for the attestation specified by the --type parameter, which in this case is the SPDX attestation. You will receive output that verifies the SBOM attestation signature in cosign's transparency log:
+
+```shell
+Verification for ghcr.io/gitguardian/wolfi/bun:latest --
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - Existence of the claims in the transparency log was verified offline
+  - The code-signing certificate was verified using trusted certificate authority certificates
+Certificate subject: https://github.com/GitGuardian/wolfi/.github/workflows/release.yaml@refs/heads/main
+Certificate issuer URL: https://token.actions.githubusercontent.com
+GitHub Workflow Trigger: push
+GitHub Workflow SHA: ced6b3cfab1341509de55bff7c0389ce81f73aae
+GitHub Workflow Name: bun
+GitHub Workflow Repository: GitGuardian/wolfi
+GitHub Workflow Ref: refs/heads/main
+...
+```
+
+#### Download the Image SBOM Attestations
+
+To download an attestation, use the `cosign` download attestation command and provide both the predicate type and the build platform. For example, the following command will obtain the SBOM for the bun image on `linux/amd64`:
+
+- **Production image**
+
+```shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  ghcr.io/gitguardian/wolfi/bun:latest | jq -r .payload | base64 -d | jq .predicate
+```
+
+- **Shell image**
+
+```shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  ghcr.io/gitguardian/wolfi/bun:latest-shell | jq -r .payload | base64 -d | jq .predicate
+```

--- a/images/bun/dev.yaml
+++ b/images/bun/dev.yaml
@@ -1,0 +1,15 @@
+include: images/bun/shell.yaml
+
+contents:
+  packages:
+    - apk-tools
+    - build-base
+    - gettext
+    - git
+    - minify
+    - vim
+    - vite
+    - wolfi-keys
+
+accounts:
+  run-as: root

--- a/images/bun/latest/dev.yaml
+++ b/images/bun/latest/dev.yaml
@@ -1,0 +1,1 @@
+include: images/bun/dev.yaml

--- a/images/bun/latest/prod.yaml
+++ b/images/bun/latest/prod.yaml
@@ -1,0 +1,1 @@
+include: images/bun/prod.yaml

--- a/images/bun/latest/shell.yaml
+++ b/images/bun/latest/shell.yaml
@@ -1,0 +1,1 @@
+include: images/bun/shell.yaml

--- a/images/bun/prod.yaml
+++ b/images/bun/prod.yaml
@@ -1,0 +1,18 @@
+include: images/apko.yaml
+
+contents:
+  packages:
+    - ca-certificates-bundle
+    - glibc-locale-posix
+    - bun
+    - wolfi-baselayout
+
+entrypoint:
+  command: /usr/bin/bun
+
+cmd: --help
+
+annotations:
+  org.opencontainers.image.title: 'bun'
+  org.opencontainers.image.description: 'Bun image based on Wolfi OS'
+  org.opencontainers.image.source: 'https://github.com/GitGuardian/wolfi/tree/main/images/bun'

--- a/images/bun/prod.yaml
+++ b/images/bun/prod.yaml
@@ -10,8 +10,6 @@ contents:
 entrypoint:
   command: /usr/bin/bun
 
-cmd: --help
-
 annotations:
   org.opencontainers.image.title: 'bun'
   org.opencontainers.image.description: 'Bun image based on Wolfi OS'

--- a/images/bun/shell.yaml
+++ b/images/bun/shell.yaml
@@ -1,0 +1,9 @@
+include: images/bun/prod.yaml
+
+contents:
+  packages:
+    - bash
+    - busybox
+    - curl
+    - openssl
+    - wget


### PR DESCRIPTION
Add a zero-CVE Bun runtime image (prod, shell, dev) for use as the frontend app base image, with CI workflow and documentation.