### PR TITLE
chore(loki): add 3.6.10, 3.6.8 and remove 3.5.x

### DIFF
--- a/.github/workflows/loki.yaml
+++ b/.github/workflows/loki.yaml
@@ -29,7 +29,7 @@ jobs:
   publish:
     strategy:
       matrix:
-        version: [latest, "3.6", "3.6.7", "3.6.5", "3.6.3", "3.6.2", "3.5", "3.5.8"]
+        version: [latest, "3.6", "3.6.10", "3.6.8", "3.6.7"]
         variant: [prod, shell]
     name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || '' }}
     uses: './.github/workflows/release.yaml'

--- a/images/loki/README.md
+++ b/images/loki/README.md
@@ -10,18 +10,12 @@ This image contains the loki application for log aggregation. loki can be used t
 | latest-shell | ghcr.io/gitguardian/wolfi/loki:latest-shell |
 | 3.6          | ghcr.io/gitguardian/wolfi/loki:3.6          |
 | 3.6-shell    | ghcr.io/gitguardian/wolfi/loki:3.6-shell    |
+| 3.6.10       | ghcr.io/gitguardian/wolfi/loki:3.6.10       |
+| 3.6.10-shell | ghcr.io/gitguardian/wolfi/loki:3.6.10-shell |
+| 3.6.8        | ghcr.io/gitguardian/wolfi/loki:3.6.8        |
+| 3.6.8-shell  | ghcr.io/gitguardian/wolfi/loki:3.6.8-shell  |
 | 3.6.7        | ghcr.io/gitguardian/wolfi/loki:3.6.7        |
 | 3.6.7-shell  | ghcr.io/gitguardian/wolfi/loki:3.6.7-shell  |
-| 3.6.5        | ghcr.io/gitguardian/wolfi/loki:3.6.5        |
-| 3.6.5-shell  | ghcr.io/gitguardian/wolfi/loki:3.6.5-shell  |
-| 3.6.3        | ghcr.io/gitguardian/wolfi/loki:3.6.3        |
-| 3.6.3-shell  | ghcr.io/gitguardian/wolfi/loki:3.6.3-shell  |
-| 3.6.2        | ghcr.io/gitguardian/wolfi/loki:3.6.2        |
-| 3.6.2-shell  | ghcr.io/gitguardian/wolfi/loki:3.6.2-shell  |
-| 3.5.8        | ghcr.io/gitguardian/wolfi/loki:3.5.8        |
-| 3.5.8-shell  | ghcr.io/gitguardian/wolfi/loki:3.5.8-shell  |
-| 3.5          | ghcr.io/gitguardian/wolfi/loki:3.5          |
-| 3.5-shell    | ghcr.io/gitguardian/wolfi/loki:3.5-shell    |
 
 ## ✅ Verify the Provenance
 


### PR DESCRIPTION
## Summary

- Add Loki image versions `3.6.10`, `3.6.8` to the CI build matrix
- Remove deprecated `3.5`, `3.5.8`, `3.6.2`, `3.6.3`, `3.6.5` versions
- Update `images/loki/README.md` with new version table

Ref: [ENT-3785](https://linear.app/gitguardian/issue/ENT-3785/self-hosted-release-202640-non-skippable-based-on-saas-v2xx)

## Test plan

- [ ] CI workflow runs successfully and builds all version tags
- [ ] Verify images are pushed to GHCR for 3.6.10, 3.6.8 (prod + shell variants)
- [ ] Confirm removed versions are no longer rebuilt