### PR TITLE
chore(minio): add 0.20260323, 0.20260330 and remove old versions

### DIFF
--- a/.github/workflows/minio.yaml
+++ b/.github/workflows/minio.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         # https://images.chainguard.dev/directory/image/minio/versions
-        version: [latest, "0.20251015", "0.20250907", "0.20250723"]
+        version: [latest, "0.20260330", "0.20260323", "0.20251015"]
         variant: ["prod"]
     name: ${{ matrix.version }}
     uses: './.github/workflows/release.yaml'

--- a/images/minio/0.20260323/prod.yaml
+++ b/images/minio/0.20260323/prod.yaml
@@ -2,5 +2,5 @@ include: images/minio/prod.yaml
 
 contents:
   packages:
-    - mc~0.20250721
-    - minio~0.20250723
+    - mc~0.20250813
+    - minio~0.20260323

--- a/images/minio/0.20260330/prod.yaml
+++ b/images/minio/0.20260330/prod.yaml
@@ -3,4 +3,4 @@ include: images/minio/prod.yaml
 contents:
   packages:
     - mc~0.20250813
-    - minio~0.20250907
+    - minio~0.20260330

--- a/images/minio/README.md
+++ b/images/minio/README.md
@@ -7,9 +7,9 @@ Minimal image with Minio.
 | 📌 Version  | ⬇️ Pull URL                               | Support |
 | ---------- | ------------------------------------------ | ------- |
 | latest     | ghcr.io/gitguardian/wolfi/minio:latest     | ✅       |
+| 0.20260330 | ghcr.io/gitguardian/wolfi/minio:0.20260330 | ✅       |
+| 0.20260323 | ghcr.io/gitguardian/wolfi/minio:0.20260323 | ✅       |
 | 0.20251015 | ghcr.io/gitguardian/wolfi/minio:0.20251015 | ✅       |
-| 0.20250907 | ghcr.io/gitguardian/wolfi/minio:0.20250907 | ✅       |
-| 0.20250723 | ghcr.io/gitguardian/wolfi/minio:0.20250723 | ✅       |
 
 
 ## ✅ Verify the Provenance


### PR DESCRIPTION
## Summary

- Add MinIO image versions `0.20260323` and `0.20260330` to the CI build matrix (with `mc~0.20250813`)
- Remove deprecated `0.20250723` and `0.20250907` versions
- Update `images/minio/README.md` accordingly

Ref: [ENT-3785](https://linear.app/gitguardian/issue/ENT-3785/self-hosted-release-202640-non-skippable-based-on-saas-v2xx)

## Test plan

- [ ] CI workflow runs successfully and builds new version tags
- [ ] Verify images are pushed to GHCR for 0.20260323 and 0.20260330
- [ ] Confirm 0.20250723 and 0.20250907 are no longer rebuilt