### PR TITLE
chore(fluent-bit): add 4.2.3, 4.2.4 and remove 4.0.{0,2}

### DIFF
--- a/.github/workflows/fluent-bit.yaml
+++ b/.github/workflows/fluent-bit.yaml
@@ -29,7 +29,7 @@ jobs:
   publish:
     strategy:
       matrix:
-        version: [latest, "4.2", "4.2.2", "4.0", "4.0.3", "4.0.2", "4.0.0"]
+        version: [latest, "4.2", "4.2.4", "4.2.3", "4.2.2", "4.0", "4.0.3"]
         variant: [prod, shell]
     name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || '' }}
     uses: './.github/workflows/release.yaml'

--- a/images/fluent-bit/README.md
+++ b/images/fluent-bit/README.md
@@ -10,16 +10,16 @@ Fluent Bit is a lightweight and high performance log processor.
 | latest-shell | ghcr.io/gitguardian/wolfi/fluent-bit:latest-shell | ✅       |
 | 4.2          | ghcr.io/gitguardian/wolfi/fluent-bit:4.2          | ✅       |
 | 4.2-shell    | ghcr.io/gitguardian/wolfi/fluent-bit:4.2-shell    | ✅       |
+| 4.2.4        | ghcr.io/gitguardian/wolfi/fluent-bit:4.2.4        | ✅       |
+| 4.2.4-shell  | ghcr.io/gitguardian/wolfi/fluent-bit:4.2.4-shell  | ✅       |
+| 4.2.3        | ghcr.io/gitguardian/wolfi/fluent-bit:4.2.3        | ✅       |
+| 4.2.3-shell  | ghcr.io/gitguardian/wolfi/fluent-bit:4.2.3-shell  | ✅       |
 | 4.2.2        | ghcr.io/gitguardian/wolfi/fluent-bit:4.2.2        | ✅       |
 | 4.2.2-shell  | ghcr.io/gitguardian/wolfi/fluent-bit:4.2.2-shell  | ✅       |
 | 4.0          | ghcr.io/gitguardian/wolfi/fluent-bit:4.0          | ✅       |
 | 4.0-shell    | ghcr.io/gitguardian/wolfi/fluent-bit:4.0-shell    | ✅       |
 | 4.0.3        | ghcr.io/gitguardian/wolfi/fluent-bit:4.0.3        | ✅       |
 | 4.0.3-shell  | ghcr.io/gitguardian/wolfi/fluent-bit:4.0.3-shell  | ✅       |
-| 4.0.2        | ghcr.io/gitguardian/wolfi/fluent-bit:4.0.2        | ✅       |
-| 4.0.2-shell  | ghcr.io/gitguardian/wolfi/fluent-bit:4.0.2-shell  | ✅       |
-| 4.0.0        | ghcr.io/gitguardian/wolfi/fluent-bit:4.0.0        | ✅       |
-| 4.0.0-shell  | ghcr.io/gitguardian/wolfi/fluent-bit:4.0.0-shell  | ✅       |
 | 3.2          | ghcr.io/gitguardian/wolfi/fluent-bit:3.2          | ❌       |
 | 3.2-shell    | ghcr.io/gitguardian/wolfi/fluent-bit:3.2-shell    | ❌       |
 


### PR DESCRIPTION
## Summary

- Add Fluent Bit image versions `4.2.3` and `4.2.4` to the CI build matrix
- Remove deprecated `4.0.0` and `4.0.2` (kept `4.0` floating tag and `4.0.3`)
- Update `images/fluent-bit/README.md` versions table

Final matrix: `[latest, "4.2", "4.2.4", "4.2.3", "4.2.2", "4.0", "4.0.3"]`

## References

- [ENT-3785](https://linear.app/gitguardian/issue/ENT-3785/self-hosted-release-202640-non-skippable-based-on-saas-v24311) — Self-Hosted Release 2026.4.0

## Test plan

- [ ] CI workflow runs successfully and builds the new tags
- [ ] Verify images are pushed to GHCR for 4.2.3 and 4.2.4 (prod + shell variants)
- [ ] Confirm 4.0.0 and 4.0.2 images are no longer rebuilt