### PR TITLE
fix(bun): pin bun to exact 1.3.11 in 1.3 image

### DIFF
--- a/images/bun/1.3/dev.yaml
+++ b/images/bun/1.3/dev.yaml
@@ -2,4 +2,4 @@ include: images/bun/dev.yaml
 
 contents:
   packages:
-    - bun~1.3
+    - bun=1.3.11

--- a/images/bun/1.3/prod.yaml
+++ b/images/bun/1.3/prod.yaml
@@ -2,4 +2,4 @@ include: images/bun/prod.yaml
 
 contents:
   packages:
-    - bun~1.3
+    - bun=1.3.11

--- a/images/bun/1.3/shell.yaml
+++ b/images/bun/1.3/shell.yaml
@@ -2,4 +2,4 @@ include: images/bun/shell.yaml
 
 contents:
   packages:
-    - bun~1.3
+    - bun=1.3.11


### PR DESCRIPTION
The apk constraint bun~1.3 resolved to bun 1.3.11-canary.1 which differs from the stable 1.3.11 used locally. Pin to exact version to ensure consistency between local dev and CI.