### PR TITLE
chore(apache-tika): add version 3.3

### DIFF
--- a/.github/workflows/apache-tika.yaml
+++ b/.github/workflows/apache-tika.yaml
@@ -29,7 +29,7 @@ jobs:
   publish:
     strategy:
       matrix:
-        version: [latest, "3.1", "3.2"]
+        version: [latest, "3.1", "3.2", "3.3"]
         variant: [prod, shell]
     name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || '' }}
     uses: './.github/workflows/release.yaml'

--- a/images/apache-tika/3.3/prod.yaml
+++ b/images/apache-tika/3.3/prod.yaml
@@ -1,0 +1,6 @@
+include: images/apache-tika/prod.yaml
+
+contents:
+  packages:
+    - apache-tika-3.3
+    - apache-tika-3.3-compat

--- a/images/apache-tika/3.3/shell.yaml
+++ b/images/apache-tika/3.3/shell.yaml
@@ -1,0 +1,6 @@
+include: images/apache-tika/shell.yaml
+
+contents:
+  packages:
+    - apache-tika-3.3
+    - apache-tika-3.3-compat

--- a/images/apache-tika/README.md
+++ b/images/apache-tika/README.md
@@ -12,6 +12,8 @@ Apache Tika extracts metadata, text, and language from documents, enabling conte
 | 3.1-shell    | ghcr.io/gitguardian/wolfi/apache-tika:3.1-shell    |
 | 3.2          | ghcr.io/gitguardian/wolfi/apache-tika:3.2          |
 | 3.2-shell    | ghcr.io/gitguardian/wolfi/apache-tika:3.2-shell    |
+| 3.3          | ghcr.io/gitguardian/wolfi/apache-tika:3.3          |
+| 3.3-shell    | ghcr.io/gitguardian/wolfi/apache-tika:3.3-shell    |
 
 ## ✅ Verify the Provenance
 


### PR DESCRIPTION
## Summary

- Add Apache Tika `3.3` build (prod + shell variants)
- Update workflow matrix and README

## Changes

- New `images/apache-tika/3.3/prod.yaml` (apache-tika-3.3 + compat)
- New `images/apache-tika/3.3/shell.yaml` (apache-tika-3.3 + compat)
- Updated `.github/workflows/apache-tika.yaml` matrix
- Updated `images/apache-tika/README.md` versions table