### PR TITLE
chore(python-gitguardian,dev): bump to postgresql-18-dev

### DIFF
--- a/images/python-gitguardian/dev.yaml
+++ b/images/python-gitguardian/dev.yaml
@@ -6,7 +6,7 @@ contents:
     - build-base
     - docker-compose
     - git
-    - postgresql-16-dev
+    - postgresql-18-dev
     - ruff
     - uv
     - vim

--- a/images/python-gitguardian/prod.yaml
+++ b/images/python-gitguardian/prod.yaml
@@ -11,7 +11,7 @@ contents:
     - git
     - glibc-locale-posix
     - libgcrypt
-    - libpq-16
+    - libpq-18
     - pango
     - ripgrep
     - tini


### PR DESCRIPTION
We now use 18 as base, and the 16 deps makes the CI fail

Though, as we modify the prod image as well, i'm wondering about the impact on GIM associated with a PG 16 server?