### PR TITLE
chore(loki): bump to 3.7.1 and remove 3.6.x versions

### DIFF
--- a/.github/workflows/loki.yaml
+++ b/.github/workflows/loki.yaml
@@ -29,7 +29,7 @@ jobs:
   publish:
     strategy:
       matrix:
-        version: [latest, "3.6", "3.6.10", "3.6.8", "3.6.7"]
+        version: [latest, "3.7", "3.7.1", "3.6.10", "3.6.8"]
         variant: [prod, shell]
     name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || '' }}
     uses: './.github/workflows/release.yaml'

--- a/images/loki/README.md
+++ b/images/loki/README.md
@@ -8,14 +8,14 @@ This image contains the loki application for log aggregation. loki can be used t
 | ------------ | ------------------------------------------- |
 | latest       | ghcr.io/gitguardian/wolfi/loki:latest       |
 | latest-shell | ghcr.io/gitguardian/wolfi/loki:latest-shell |
-| 3.6          | ghcr.io/gitguardian/wolfi/loki:3.6          |
-| 3.6-shell    | ghcr.io/gitguardian/wolfi/loki:3.6-shell    |
+| 3.7          | ghcr.io/gitguardian/wolfi/loki:3.7          |
+| 3.7-shell    | ghcr.io/gitguardian/wolfi/loki:3.7-shell    |
+| 3.7.1        | ghcr.io/gitguardian/wolfi/loki:3.7.1        |
+| 3.7.1-shell  | ghcr.io/gitguardian/wolfi/loki:3.7.1-shell  |
 | 3.6.10       | ghcr.io/gitguardian/wolfi/loki:3.6.10       |
 | 3.6.10-shell | ghcr.io/gitguardian/wolfi/loki:3.6.10-shell |
 | 3.6.8        | ghcr.io/gitguardian/wolfi/loki:3.6.8        |
 | 3.6.8-shell  | ghcr.io/gitguardian/wolfi/loki:3.6.8-shell  |
-| 3.6.7        | ghcr.io/gitguardian/wolfi/loki:3.6.7        |
-| 3.6.7-shell  | ghcr.io/gitguardian/wolfi/loki:3.6.7-shell  |
 
 ## ✅ Verify the Provenance
 


### PR DESCRIPTION
## Summary

- Add Loki image versions `3.7` and `3.7.1` to the build matrix
- Remove deprecated `3.6` (minor alias) and `3.6.7` patch
- Keep `3.6.10` and `3.6.8` patches for users still on 3.6.x
- Update `README.md` version table accordingly

## Notes

- Loki 3.7.1 is available in the Wolfi APK index (`loki-3.7` package, latest revision `3.7.1-r2`)
- The `latest` tag is unconstrained in the workflow and will automatically pick up 3.7.1 from upstream
- Unlike #45 (3.5.x → 3.6.x, full minor drop), we keep recent 3.6.x patches as a transition path

## Test plan

- [ ] CI matrix builds all 8 tags successfully (`3.7`, `3.7-shell`, `3.7.1`, `3.7.1-shell`, `3.6.10`, `3.6.10-shell`, `3.6.8`, `3.6.8-shell`)
- [ ] `latest` and `latest-shell` resolve to 3.7.1 after the workflow runs on `main`
- [ ] Smoke-test: `docker run --rm ghcr.io/gitguardian/wolfi/loki:3.7.1 -version` reports `3.7.1`