### PR TITLE
chore(fluent-bit): add version 5.0.5

### DIFF
--- a/.github/workflows/fluent-bit.yaml
+++ b/.github/workflows/fluent-bit.yaml
@@ -29,7 +29,7 @@ jobs:
   publish:
     strategy:
       matrix:
-        version: [latest, "4.2", "4.2.4", "4.2.3", "4.2.2", "4.0", "4.0.3"]
+        version: [latest, "5.0.5", "4.2", "4.2.4", "4.2.3", "4.2.2", "4.0", "4.0.3"]
         variant: [prod, shell]
     name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || '' }}
     uses: './.github/workflows/release.yaml'

--- a/.github/workflows/fluent-bit.yaml
+++ b/.github/workflows/fluent-bit.yaml
@@ -29,7 +29,7 @@ jobs:
   publish:
     strategy:
       matrix:
-        version: [latest, "5.0.5", "4.2", "4.2.4", "4.2.3", "4.2.2", "4.0", "4.0.3"]
+        version: [latest, "5.0", "5.0.5", "4.2", "4.2.4", "4.2.3", "4.2.2", "4.0", "4.0.3"]
         variant: [prod, shell]
     name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || '' }}
     uses: './.github/workflows/release.yaml'

--- a/images/fluent-bit/README.md
+++ b/images/fluent-bit/README.md
@@ -8,6 +8,8 @@ Fluent Bit is a lightweight and high performance log processor.
 | ------------ | ------------------------------------------------- | ------- |
 | latest       | ghcr.io/gitguardian/wolfi/fluent-bit:latest       | ✅       |
 | latest-shell | ghcr.io/gitguardian/wolfi/fluent-bit:latest-shell | ✅       |
+| 5.0          | ghcr.io/gitguardian/wolfi/fluent-bit:5.0          | ✅       |
+| 5.0-shell    | ghcr.io/gitguardian/wolfi/fluent-bit:5.0-shell    | ✅       |
 | 5.0.5        | ghcr.io/gitguardian/wolfi/fluent-bit:5.0.5        | ✅       |
 | 5.0.5-shell  | ghcr.io/gitguardian/wolfi/fluent-bit:5.0.5-shell  | ✅       |
 | 4.2          | ghcr.io/gitguardian/wolfi/fluent-bit:4.2          | ✅       |

--- a/images/fluent-bit/README.md
+++ b/images/fluent-bit/README.md
@@ -8,6 +8,8 @@ Fluent Bit is a lightweight and high performance log processor.
 | ------------ | ------------------------------------------------- | ------- |
 | latest       | ghcr.io/gitguardian/wolfi/fluent-bit:latest       | ✅       |
 | latest-shell | ghcr.io/gitguardian/wolfi/fluent-bit:latest-shell | ✅       |
+| 5.0.5        | ghcr.io/gitguardian/wolfi/fluent-bit:5.0.5        | ✅       |
+| 5.0.5-shell  | ghcr.io/gitguardian/wolfi/fluent-bit:5.0.5-shell  | ✅       |
 | 4.2          | ghcr.io/gitguardian/wolfi/fluent-bit:4.2          | ✅       |
 | 4.2-shell    | ghcr.io/gitguardian/wolfi/fluent-bit:4.2-shell    | ✅       |
 | 4.2.4        | ghcr.io/gitguardian/wolfi/fluent-bit:4.2.4        | ✅       |


### PR DESCRIPTION
## Summary
- Add fluent-bit `5.0.5` to the build matrix
- Single matrix entry — fluent-bit uses the `packages: fluent-bit~{version}` mechanism (no per-version YAML file needed, unlike `minio`)

## Test plan
- [ ] CI builds the new `5.0.5/prod` and `5.0.5-shell` variants successfully
- [ ] Images are published to GHCR alongside the existing versions