### PR TITLE
chore(loki): add version 3.7.2

### DIFF
--- a/.github/workflows/loki.yaml
+++ b/.github/workflows/loki.yaml
@@ -29,7 +29,7 @@ jobs:
   publish:
     strategy:
       matrix:
-        version: [latest, "3.7", "3.7.1", "3.6.10", "3.6.8"]
+        version: [latest, "3.7", "3.7.2", "3.7.1", "3.6.10", "3.6.8"]
         variant: [prod, shell]
     name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || '' }}
     uses: './.github/workflows/release.yaml'

--- a/images/loki/README.md
+++ b/images/loki/README.md
@@ -10,6 +10,8 @@ This image contains the loki application for log aggregation. loki can be used t
 | latest-shell | ghcr.io/gitguardian/wolfi/loki:latest-shell |
 | 3.7          | ghcr.io/gitguardian/wolfi/loki:3.7          |
 | 3.7-shell    | ghcr.io/gitguardian/wolfi/loki:3.7-shell    |
+| 3.7.2        | ghcr.io/gitguardian/wolfi/loki:3.7.2        |
+| 3.7.2-shell  | ghcr.io/gitguardian/wolfi/loki:3.7.2-shell  |
 | 3.7.1        | ghcr.io/gitguardian/wolfi/loki:3.7.1        |
 | 3.7.1-shell  | ghcr.io/gitguardian/wolfi/loki:3.7.1-shell  |
 | 3.6.10       | ghcr.io/gitguardian/wolfi/loki:3.6.10       |


### PR DESCRIPTION
## Summary
- Add Loki `3.7.2` to the build matrix (bumps both `loki` and `logcli` packages — same pattern as `3.7.1`)
- README updated with the two new image entries (`3.7.2` and `3.7.2-shell`)

## Linked
- Release ticket: [ENT-3853 — Self-Hosted Release 2026.5.0 based on SaaS v2.454](https://linear.app/gitguardian/issue/ENT-3853/self-hosted-release-202650-based-on-saas-v2454)

## Test plan
- [ ] CI builds the new `3.7.2/prod` and `3.7.2-shell` variants successfully
- [ ] Images published to GHCR alongside the existing versions