### PR TITLE
chore(minio): add version 0.20260512

### DIFF
--- a/.github/workflows/minio.yaml
+++ b/.github/workflows/minio.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         # https://images.chainguard.dev/directory/image/minio/versions
-        version: [latest, "0.20260504", "0.20260410", "0.20260330", "0.20260323", "0.20251015"]
+        version: [latest, "0.20260512", "0.20260504", "0.20260410", "0.20260330", "0.20260323", "0.20251015"]
         variant: ["prod"]
     name: ${{ matrix.version }}
     uses: './.github/workflows/release.yaml'

--- a/images/minio/0.20260512/prod.yaml
+++ b/images/minio/0.20260512/prod.yaml
@@ -1,0 +1,6 @@
+include: images/minio/prod.yaml
+
+contents:
+  packages:
+    - mc~0.20250813
+    - minio~0.20260512

--- a/images/minio/README.md
+++ b/images/minio/README.md
@@ -7,6 +7,7 @@ Minimal image with Minio.
 | 📌 Version  | ⬇️ Pull URL                               | Support |
 | ---------- | ------------------------------------------ | ------- |
 | latest     | ghcr.io/gitguardian/wolfi/minio:latest     | ✅       |
+| 0.20260512 | ghcr.io/gitguardian/wolfi/minio:0.20260512 | ✅       |
 | 0.20260504 | ghcr.io/gitguardian/wolfi/minio:0.20260504 | ✅       |
 | 0.20260410 | ghcr.io/gitguardian/wolfi/minio:0.20260410 | ✅       |
 | 0.20260330 | ghcr.io/gitguardian/wolfi/minio:0.20260330 | ✅       |


### PR DESCRIPTION
## Summary
- Add MinIO `0.20260512` to the build matrix
- New file `images/minio/0.20260512/prod.yaml` follows the same pattern as `0.20260504` (`mc~0.20250813` + `minio~0.20260512`)
- README updated with the new image entry

## Linked
- Release ticket: [ENT-3853 — Self-Hosted Release 2026.5.0 based on SaaS v2.454](https://linear.app/gitguardian/issue/ENT-3853/self-hosted-release-202650-based-on-saas-v2454)

## Test plan
- [ ] CI builds the new `0.20260512/prod` variant successfully
- [ ] Image published to GHCR alongside the existing versions

Source: https://images.chainguard.dev/directory/image/minio/versions