### PR TITLE
chore(minio): add 0.20260520 and remove 0.20251015

### DIFF
--- a/.github/workflows/minio.yaml
+++ b/.github/workflows/minio.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         # https://images.chainguard.dev/directory/image/minio/versions
-        version: [latest, "0.20260520", "0.20260512", "0.20260504", "0.20260410", "0.20260330", "0.20260323", "0.20251015"]
+        version: [latest, "0.20260520", "0.20260512", "0.20260504", "0.20260410", "0.20260330", "0.20260323"]
         variant: ["prod"]
     name: ${{ matrix.version }}
     uses: './.github/workflows/release.yaml'

--- a/.github/workflows/minio.yaml
+++ b/.github/workflows/minio.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         # https://images.chainguard.dev/directory/image/minio/versions
-        version: [latest, "0.20260512", "0.20260504", "0.20260410", "0.20260330", "0.20260323", "0.20251015"]
+        version: [latest, "0.20260520", "0.20260512", "0.20260504", "0.20260410", "0.20260330", "0.20260323", "0.20251015"]
         variant: ["prod"]
     name: ${{ matrix.version }}
     uses: './.github/workflows/release.yaml'

--- a/images/minio/0.20251015/prod.yaml
+++ b/images/minio/0.20251015/prod.yaml
@@ -1,6 +1,0 @@
-include: images/minio/prod.yaml
-
-contents:
-  packages:
-    - mc~0.20250813
-    - minio~0.20251015

--- a/images/minio/0.20260520/prod.yaml
+++ b/images/minio/0.20260520/prod.yaml
@@ -1,0 +1,6 @@
+include: images/minio/prod.yaml
+
+contents:
+  packages:
+    - mc~0.20250813
+    - minio~0.20260520

--- a/images/minio/README.md
+++ b/images/minio/README.md
@@ -13,7 +13,6 @@ Minimal image with Minio.
 | 0.20260410 | ghcr.io/gitguardian/wolfi/minio:0.20260410 | ✅       |
 | 0.20260330 | ghcr.io/gitguardian/wolfi/minio:0.20260330 | ✅       |
 | 0.20260323 | ghcr.io/gitguardian/wolfi/minio:0.20260323 | ✅       |
-| 0.20251015 | ghcr.io/gitguardian/wolfi/minio:0.20251015 | ✅       |
 
 
 ## ✅ Verify the Provenance

--- a/images/minio/README.md
+++ b/images/minio/README.md
@@ -7,6 +7,7 @@ Minimal image with Minio.
 | 📌 Version  | ⬇️ Pull URL                               | Support |
 | ---------- | ------------------------------------------ | ------- |
 | latest     | ghcr.io/gitguardian/wolfi/minio:latest     | ✅       |
+| 0.20260520 | ghcr.io/gitguardian/wolfi/minio:0.20260520 | ✅       |
 | 0.20260512 | ghcr.io/gitguardian/wolfi/minio:0.20260512 | ✅       |
 | 0.20260504 | ghcr.io/gitguardian/wolfi/minio:0.20260504 | ✅       |
 | 0.20260410 | ghcr.io/gitguardian/wolfi/minio:0.20260410 | ✅       |


### PR DESCRIPTION
## Summary

- **Add** MinIO `0.20260520` to the GitGuardian Wolfi image catalog, matching the upstream Chainguard release ([directory](https://images.chainguard.dev/directory/image/minio/versions)).
- **Drop** MinIO `0.20251015` from the catalog — the matrix had accumulated 7 versions, and this is the oldest still building. Pattern matches PR #53 (loki bump + drop).

## Changes

### Adding 0.20260520
- New `images/minio/0.20260520/prod.yaml` (pins `mc~0.20250813` and `minio~0.20260520`, same shape as the previous bump).
- `.github/workflows/minio.yaml` matrix gains `0.20260520`.
- README version table gains the new entry.

### Removing 0.20251015
- `images/minio/0.20251015/` directory deleted.
- `.github/workflows/minio.yaml` matrix loses `0.20251015`.
- README version table row removed.

## Test plan

- [ ] CI minio workflow builds `0.20260520` successfully (new matrix entry).
- [ ] CI minio workflow does **not** attempt to build `0.20251015` anymore.
- [ ] `ghcr.io/gitguardian/wolfi/minio:0.20260520` resolves once merged.
- [ ] Existing consumers of `0.20251015` already migrated to a newer tag (verified prior to this PR).