### PR TITLE
feat(shell): add getconf via posix-libc-utils

### DIFF
--- a/images/shell/prod.yaml
+++ b/images/shell/prod.yaml
@@ -11,6 +11,7 @@ contents:
     - glibc-locale-posix
     - jq
     - netcat-openbsd
+    - posix-libc-utils
     - wget
     - wolfi-baselayout
     - yq


### PR DESCRIPTION
## Motivation

The `shell` image (`ghcr.io/gitguardian/wolfi/shell`) is used as a CI base image but does **not** ship `getconf`. `getconf` is a standard glibc utility that many install scripts rely on for platform/libc detection, so its absence silently breaks them.

Concrete failure: Railway's official CLI installer

```sh
curl -fsSL https://railway.com/install.sh | bash
```

fails inside the current shell image. Its `detect_arch()` does:

```sh
if [ "${arch}" = "x86_64" ] && [ "$(getconf LONG_BIT)" -eq 32 ]; then ...
```

Without `getconf` this prints `getconf: command not found` and `[: : integer expected`, leaving the architecture/target unresolved so the download/unpack step aborts (`tar: : not found in archive`) and nothing installs.

## Change

Add `posix-libc-utils` to `images/shell/prod.yaml` (kept alphabetically sorted). This is the Wolfi package that provides `/usr/bin/getconf` (via its `posix-libc-utils-bin` dependency), confirmed with `apk search cmd:getconf`. It is also the same package already used by the `pgvector` image, so it matches existing repo convention. `dev.yaml` includes `prod.yaml`, so the dev variant inherits the fix.

## Verification

All run against `cgr.dev/chainguard/wolfi-base` (the same apk universe), on `linux/amd64` to mirror GitLab CI runners.

**getconf is provided:**

```
$ apk add -q posix-libc-utils && command -v getconf && getconf LONG_BIT && getconf _NPROCESSORS_ONLN
/usr/bin/getconf
64
12
```

**Before (no getconf, mirrors current shell image):** the installer fails at arch detection with `getconf: command not found` / `[: : integer expected`.

**After (with `posix-libc-utils`):** the Railway installer runs to completion:

```
> Installing railway, please wait…
✓ railway was installed successfully to ~/.railway/bin/railway
$ ~/.railway/bin/railway --version
railway 5.20.0
```

Note: in the sandbox the unauthenticated `api.github.com` "latest version" lookup hits GitHub's anonymous rate limit (unrelated to this change; pinning a version avoids it). Separately, busybox's `tar` rejects the installer's empty-string flag argument that GNU `tar` tolerates — also unrelated to `getconf` and out of scope here; the end-to-end success above used `gnutar` to isolate the `getconf` fix. The `getconf`-specific failure is fully resolved by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)