### PR TITLE
feat(shell): add gnutar so GNU-tar install scripts work

### DIFF
--- a/images/shell/prod.yaml
+++ b/images/shell/prod.yaml
@@ -9,6 +9,7 @@ contents:
     - dockerize
     - gettext
     - glibc-locale-posix
+    - gnutar
     - jq
     - netcat-openbsd
     - posix-libc-utils


### PR DESCRIPTION
## What

Add the `gnutar` package to the `shell` image, providing `/usr/bin/tar` as GNU tar (shadowing the busybox `tar` applet).

## Why

The image only shipped busybox tar. Many `curl | bash` installers pass an empty-string argument to tar that GNU tar tolerates but busybox does not. Concretely, Railway's official installer (`railway.com/install.sh`) runs:

```sh
flags=$(test -n)                      # always evaluates to ""
${sudo} tar "${flags}" -xzf "${archive}" -C "${bin_dir}"   # -> tar "" -xzf ...
```

With busybox tar that fails at extraction:

```
tar: : not found in archive
```

This is the second blocker (after #60 added `getconf`) preventing the `shell` image from running the public Railway installer in CI.

## Verification (linux/amd64)

Replicating the post-merge image (`posix-libc-utils` + `gnutar`) in `wolfi-base`:

```
$ apk add -q bash curl ca-certificates-bundle posix-libc-utils gnutar wget
$ tar --version | head -1
tar (GNU tar) 1.35.90
$ RAILWAY_VERSION=5.20.0 curl -fsSL https://railway.com/install.sh | bash -s -- -f
$ ~/.railway/bin/railway --version
railway 5.20.0
```

Before (busybox tar): `tar: : not found in archive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
