### PR TITLE
feat(clickhouse-backup): add zero-CVE Wolfi image (ENT-4031)

### DIFF
--- a/.github/workflows/clickhouse-backup.yaml
+++ b/.github/workflows/clickhouse-backup.yaml
@@ -1,0 +1,39 @@
+name: clickhouse-backup
+
+on:
+  schedule:
+    - cron: "00 01 * * 1-5"
+  pull_request:
+    paths:
+      - .github/workflows/clickhouse-backup.yaml
+      - 'images/clickhouse-backup/*.yaml'
+      - 'images/clickhouse-backup/**/*.yaml'
+  push:
+    branches:
+      - 'main'
+    paths:
+      - .github/workflows/clickhouse-backup.yaml
+      - 'images/clickhouse-backup/*.yaml'
+      - 'images/clickhouse-backup/**/*.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+  security-events: write
+  actions: read
+
+jobs:
+  publish:
+    strategy:
+      matrix:
+        version: [latest, "2.7.4"]
+        variant: ["prod", "shell"]
+    name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || '' }}
+    uses: './.github/workflows/release.yaml'
+    with:
+      tag: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || '' }}
+      target: ${{ format('{0}/{1}', matrix.version, matrix.variant) }}
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 | [apache-tika](./images/apache-tika/)                           | `docker pull ghcr.io/gitguardian/wolfi/apache-tika`              |
 | [bash](./images/bash/)                                         | `docker pull ghcr.io/gitguardian/wolfi/bash`                     |
 | [bun](./images/bun/)                                           | `docker pull ghcr.io/gitguardian/wolfi/bun`                      |
+| [clickhouse-backup](./images/clickhouse-backup/)               | `docker pull ghcr.io/gitguardian/wolfi/clickhouse-backup`        |
 | [fluent-bit](./images/fluent-bit/)                             | `docker pull ghcr.io/gitguardian/wolfi/fluent-bit`               |
 | [ggshield](./images/ggshield/)                                 | `docker pull ghcr.io/gitguardian/wolfi/ggshield`                 |
 | [helm](./images/helm/)                                         | `docker pull ghcr.io/gitguardian/wolfi/helm`                     |

--- a/images/clickhouse-backup/2.7.4/prod.yaml
+++ b/images/clickhouse-backup/2.7.4/prod.yaml
@@ -1,0 +1,5 @@
+include: images/clickhouse-backup/prod.yaml
+
+contents:
+  packages:
+    - clickhouse-backup~2.7.4

--- a/images/clickhouse-backup/2.7.4/shell.yaml
+++ b/images/clickhouse-backup/2.7.4/shell.yaml
@@ -1,0 +1,1 @@
+include: images/clickhouse-backup/shell.yaml

--- a/images/clickhouse-backup/README.md
+++ b/images/clickhouse-backup/README.md
@@ -1,0 +1,108 @@
+# clickhouse-backup
+
+Zero-CVE [clickhouse-backup](https://github.com/Altinity/clickhouse-backup) (Altinity) image based on Wolfi OS — the backup/restore sidecar for our self-hosted ClickHouse deployment (tiered S3/Azure/GCS object storage). Default command is `server` (REST API + `--watch` mode).
+
+## Versions
+
+| Version        | Pull URL                                                    |
+| -------------- | ----------------------------------------------------------- |
+| latest         | ghcr.io/gitguardian/wolfi/clickhouse-backup:latest          |
+| latest-shell   | ghcr.io/gitguardian/wolfi/clickhouse-backup:latest-shell    |
+| 2.7.4          | ghcr.io/gitguardian/wolfi/clickhouse-backup:2.7.4           |
+| 2.7.4-shell    | ghcr.io/gitguardian/wolfi/clickhouse-backup:2.7.4-shell     |
+
+The `shell` variant adds `bash`, `busybox`, `curl`, `openssl`, and `wget` for debugging (e.g. checking object-storage reachability); the `prod` variant is minimal and runs as non-root.
+
+## Verify the Provenance
+
+GitHub CLI ([gh](https://cli.github.com/)) can be used to retrieve the build provenance, which details the exact commit, workflow, and runner that produced the image:
+
+- **Production image**
+
+```shell
+gh attestation verify \
+  --owner gitguardian \
+  oci://ghcr.io/gitguardian/wolfi/clickhouse-backup:latest
+```
+
+- **Shell image**
+
+```shell
+gh attestation verify \
+  --owner gitguardian \
+  oci://ghcr.io/gitguardian/wolfi/clickhouse-backup:latest-shell
+```
+
+## Image Verification
+
+All official images are **cryptographically signed** using [Sigstore Cosign](https://www.sigstore.dev/).
+
+### Verify the Image Signature
+
+To ensure the image is authentic and has not been tampered with, use the following command:
+
+- **Production image**
+
+```shell
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/GitGuardian/wolfi/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/gitguardian/wolfi/clickhouse-backup:latest | jq
+```
+
+- **Shell image**
+
+```shell
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/GitGuardian/wolfi/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/gitguardian/wolfi/clickhouse-backup:latest-shell | jq
+```
+
+### Image SBOMs
+
+To enhance transparency, we generate SBOMs for each release. SBOMs are available directly from the container registry and can be verified using [Sigstore Cosign](https://www.sigstore.dev/).
+
+#### Verify the Image Attestations
+
+- **Production image**
+
+```shell
+cosign verify-attestation \
+  --type=https://spdx.dev/Document \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/GitGuardian/wolfi/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/gitguardian/wolfi/clickhouse-backup:latest
+```
+
+- **Shell image**
+
+```shell
+cosign verify-attestation \
+  --type=https://spdx.dev/Document \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/GitGuardian/wolfi/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/gitguardian/wolfi/clickhouse-backup:latest-shell
+```
+
+#### Download the Image SBOM Attestations
+
+To download an attestation, use the `cosign` download attestation command and provide both the predicate type and the build platform. For example, the following command will obtain the SBOM for the clickhouse-backup image on `linux/amd64`:
+
+- **Production image**
+
+```shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  ghcr.io/gitguardian/wolfi/clickhouse-backup:latest | jq -r .payload | base64 -d | jq .predicate
+```
+
+- **Shell image**
+
+```shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  ghcr.io/gitguardian/wolfi/clickhouse-backup:latest-shell | jq -r .payload | base64 -d | jq .predicate
+```

--- a/images/clickhouse-backup/latest/prod.yaml
+++ b/images/clickhouse-backup/latest/prod.yaml
@@ -1,0 +1,1 @@
+include: images/clickhouse-backup/prod.yaml

--- a/images/clickhouse-backup/latest/shell.yaml
+++ b/images/clickhouse-backup/latest/shell.yaml
@@ -1,0 +1,1 @@
+include: images/clickhouse-backup/shell.yaml

--- a/images/clickhouse-backup/prod.yaml
+++ b/images/clickhouse-backup/prod.yaml
@@ -1,0 +1,19 @@
+include: images/apko.yaml
+
+contents:
+  packages:
+    - ca-certificates-bundle
+    - clickhouse-backup
+    - glibc-locale-posix
+    - tzdata
+    - wolfi-baselayout
+
+entrypoint:
+  command: /usr/bin/clickhouse-backup
+
+cmd: server
+
+annotations:
+  org.opencontainers.image.title: 'clickhouse-backup'
+  org.opencontainers.image.description: 'clickhouse-backup (Altinity) sidecar image based on Wolfi OS — zero-CVE backup/restore for ClickHouse'
+  org.opencontainers.image.source: 'https://github.com/GitGuardian/wolfi/tree/main/images/clickhouse-backup'

--- a/images/clickhouse-backup/shell.yaml
+++ b/images/clickhouse-backup/shell.yaml
@@ -1,0 +1,9 @@
+include: images/clickhouse-backup/prod.yaml
+
+contents:
+  packages:
+    - bash
+    - busybox
+    - curl
+    - openssl
+    - wget


### PR DESCRIPTION
## What

Adds a **zero-CVE Wolfi image for [Altinity clickhouse-backup](https://github.com/Altinity/clickhouse-backup)** (`v2.7.4`), to replace the upstream Altinity image as the backup/restore **sidecar** for our self-hosted ClickHouse deployment.

Part of the `2026.8` Self-Hosted roadmap — Linear **ENT-4031** (ClickHouse backup & DR).

## Files (follows the repo's apko convention, mirrors `minio`/`loki`)

- `images/clickhouse-backup/prod.yaml` — minimal, non-root; packages `clickhouse-backup` + `ca-certificates-bundle`, `tzdata`, `glibc-locale-posix`, `wolfi-baselayout`. Entrypoint `/usr/bin/clickhouse-backup`, default `cmd: server` (REST API + `--watch` sidecar mode).
- `images/clickhouse-backup/shell.yaml` — adds `bash`/`busybox`/`curl`/`openssl`/`wget` for debugging (object-storage reachability).
- `images/clickhouse-backup/2.7.4/` + `latest/` — version dirs (prod + shell).
- `.github/workflows/clickhouse-backup.yaml` — matrix `[latest, 2.7.4] x [prod, shell]` via the reusable `release.yaml`.
- `images/clickhouse-backup/README.md` + root `README.md` row (alphabetical).

## ⚠️ Dependency to confirm before this can go green

This repo does **not** build from source — it assembles **Chainguard-maintained packages** (`virtualapk.cgr.dev/<org>/{chainguard,extra-packages}`). This image references the package **`clickhouse-backup`**, which I could **not** confirm is present in our org's Chainguard catalog (only the `clickhouse` DB packages are).

- If the package **exists** in the catalog → CI (apko-publish to `ttl.sh` on PR) goes green as-is.
- If **not** → we must **request `clickhouse-backup` from Chainguard** (same path as the CH chart trial, ENT-3987) before merge.

Opened as **draft** for this reason — PR CI will validate package availability.

## Notes

- Version pin `clickhouse-backup~2.7.4` assumes the catalog's version string; reconcile with the actual catalog version if it differs.
- pre-commit hooks pass locally (`check-yaml`, `trailing-whitespace`, `end-of-file-fixer`).
