### PR TITLE
feat(loki): add 3.7.3 to the published tag matrix

### DIFF
--- a/.github/workflows/loki.yaml
+++ b/.github/workflows/loki.yaml
@@ -29,7 +29,7 @@ jobs:
   publish:
     strategy:
       matrix:
-        version: [latest, "3.7", "3.7.2", "3.7.1", "3.6.10", "3.6.8"]
+        version: [latest, "3.7", "3.7.3", "3.7.2", "3.7.1", "3.6.10", "3.6.8"]
         variant: [prod, shell]
     name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || '' }}
     uses: './.github/workflows/release.yaml'


### PR DESCRIPTION
## Summary

Adds `3.7.3` to the pinned tag matrix in `.github/workflows/loki.yaml`, for CVE-2026-39822 (High) on `loki-3.7`, fixed upstream in `3.7.3-r1`.

## Note

As of this PR, `3.7.3` is **not yet present** in the wolfi package feed (`packages.wolfi.dev` tops out at `loki-3.7` `3.7.2-r3`). The pinned build for this tag (`loki~3.7.3,logcli~3.7.3`) will fail to resolve until wolfi publishes it — same mechanics as the other pinned patch versions already in this matrix. Merging now so the tag starts resolving automatically as soon as it's available, without a follow-up PR.