### PR TITLE
chore(minio): add 0.20260717 and remove 0.20260330

### DIFF
--- a/.github/workflows/minio.yaml
+++ b/.github/workflows/minio.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         # https://images.chainguard.dev/directory/image/minio/versions
-        version: [latest, "0.20260604", "0.20260520", "0.20260512", "0.20260504", "0.20260410", "0.20260330"]
+        version: [latest, "0.20260717", "0.20260604", "0.20260520", "0.20260512", "0.20260504", "0.20260410"]
         variant: ["prod"]
     name: ${{ matrix.version }}
     uses: './.github/workflows/release.yaml'

--- a/images/minio/0.20260717/prod.yaml
+++ b/images/minio/0.20260717/prod.yaml
@@ -3,4 +3,4 @@ include: images/minio/prod.yaml
 contents:
   packages:
     - mc~0.20250813
-    - minio~0.20260330
+    - minio~0.20260717

--- a/images/minio/README.md
+++ b/images/minio/README.md
@@ -7,12 +7,12 @@ Minimal image with Minio.
 | 📌 Version  | ⬇️ Pull URL                               | Support |
 | ---------- | ------------------------------------------ | ------- |
 | latest     | ghcr.io/gitguardian/wolfi/minio:latest     | ✅       |
+| 0.20260717 | ghcr.io/gitguardian/wolfi/minio:0.20260717 | ✅       |
 | 0.20260604 | ghcr.io/gitguardian/wolfi/minio:0.20260604 | ✅       |
 | 0.20260520 | ghcr.io/gitguardian/wolfi/minio:0.20260520 | ✅       |
 | 0.20260512 | ghcr.io/gitguardian/wolfi/minio:0.20260512 | ✅       |
 | 0.20260504 | ghcr.io/gitguardian/wolfi/minio:0.20260504 | ✅       |
 | 0.20260410 | ghcr.io/gitguardian/wolfi/minio:0.20260410 | ✅       |
-| 0.20260330 | ghcr.io/gitguardian/wolfi/minio:0.20260330 | ✅       |
 
 
 ## ✅ Verify the Provenance


### PR DESCRIPTION
minio 0.20260717.120751-r6 fixes CVE-2026-46600, CVE-2026-56852/56853/56859/56862, CVE-2026-33818 and CVE-2026-39821. Drops the oldest pinned version (0.20260330) to keep the rolling window.
