### PR TITLE
feat(static): add minimal Wolfi image for statically-linked binaries

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -1,0 +1,39 @@
+name: static
+
+on:
+  schedule:
+    - cron: "00 01 * * 1-5"
+  pull_request:
+    paths:
+      - .github/workflows/static.yaml
+      - 'images/static/*.yaml'
+      - 'images/static/**/*.yaml'
+  push:
+    branches:
+      - 'main'
+    paths:
+      - .github/workflows/static.yaml
+      - 'images/static/*.yaml'
+      - 'images/static/**/*.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+  security-events: write
+  actions: read
+
+jobs:
+  publish:
+    strategy:
+      matrix:
+        version: [latest]
+        variant: [prod]
+    name: ${{ matrix.version }}
+    uses: './.github/workflows/release.yaml'
+    with:
+      tag: ${{ matrix.version }}
+      target: ${{ matrix.variant }}
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -40,5 +40,6 @@
 | [python-gitguardian](./images/python-gitguardian/)             | `docker pull ghcr.io/gitguardian/wolfi/python-gitguardian`       |
 | [redis-bitnami](./images/redis-bitnami/)                       | `docker pull ghcr.io/gitguardian/wolfi/redis-bitnami`            |
 | [shell](./images/shell/)                                       | `docker pull ghcr.io/gitguardian/wolfi/shell`                    |
+| [static](./images/static/)                                     | `docker pull ghcr.io/gitguardian/wolfi/static`                   |
 | [traefik](./images/traefik/)                                   | `docker pull ghcr.io/gitguardian/wolfi/traefik`                  |
 | [valkey](./images/valkey/)                                     | `docker pull ghcr.io/gitguardian/wolfi/valkey`                   |

--- a/images/static/README.md
+++ b/images/static/README.md
@@ -1,0 +1,105 @@
+# static
+
+Minimal Wolfi-based image for running statically-linked binaries (Go, Rust, C/C++).
+
+It ships only CA certificates, timezone data and a base layout with a non-root user (`nonroot`, uid/gid `65532`). There is no shell and no package manager, which keeps the attack surface minimal — a drop-in, distroless-style base for a compiled binary. Use it as the final stage of a multi-stage build and copy your statically-linked binary in.
+
+## 🚀 Usage
+
+```dockerfile
+# build stage
+FROM golang:1.24 AS build
+WORKDIR /src
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /app ./cmd/app
+
+# runtime stage — nothing but the binary, certs and tzdata
+FROM ghcr.io/gitguardian/wolfi/static:latest
+COPY --from=build /app /app
+ENTRYPOINT ["/app"]
+```
+
+The image already runs as the non-root `nonroot` user, so no `USER` directive is required.
+
+## Versions
+
+| 📌 Version | ⬇️ Pull URL                              |
+| --------- | --------------------------------------- |
+| latest    | ghcr.io/gitguardian/wolfi/static:latest |
+
+## ✅ Verify the Provenance
+
+GitHub CLI ([gh](https://cli.github.com/)) can be used to retrieve the build provenance, which details the exact commit, workflow, and runner that produced the image:
+
+- **Production image**
+
+```shell
+gh attestation verify \
+  --owner gitguardian \
+  oci://ghcr.io/gitguardian/wolfi/static:latest
+```
+
+## 📦 **Image Verification**
+
+All official images are **cryptographically signed** using [Sigstore Cosign](https://www.sigstore.dev/).
+
+### ✅ Verify the Image Signature
+
+To ensure the image is authentic and has not been tampered with, use the following command:
+
+- **Production image**
+
+```shell
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/GitGuardian/wolfi/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/gitguardian/wolfi/static:latest | jq
+```
+
+### 📦 **Image SBOMs**
+
+To enhance transparency, we generate SBOMs for each release. SBOMs are available directly from the container registry
+and can be verified using using [Sigstore Cosign](https://www.sigstore.dev/).
+
+#### ✅ Verify the Image Attestations
+
+- **Production image**
+
+```shell
+cosign verify-attestation \
+  --type=https://spdx.dev/Document \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/GitGuardian/wolfi/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/gitguardian/wolfi/static:latest
+```
+
+This will pull in the signature for the attestation specified by the --type parameter, which in this case is the SPDX attestation. You will receive output that verifies the SBOM attestation signature in cosign's transparency log:
+
+```shell
+Verification for ghcr.io/gitguardian/wolfi/static:latest --
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - Existence of the claims in the transparency log was verified offline
+  - The code-signing certificate was verified using trusted certificate authority certificates
+Certificate subject: https://github.com/GitGuardian/wolfi/.github/workflows/release.yaml@refs/heads/main
+Certificate issuer URL: https://token.actions.githubusercontent.com
+GitHub Workflow Trigger: push
+GitHub Workflow SHA: ...
+GitHub Workflow Name: static
+GitHub Workflow Repository: GitGuardian/wolfi
+GitHub Workflow Ref: refs/heads/main
+...
+```
+
+#### ✅ Download the Image SBOM Attestations
+
+To download an attestation, use the `cosign` download attestation command and provide both the predicate type and the build platform. For example, the following command will obtain the SBOM for the static image on `linux/amd64`:
+
+- **Production image**
+
+```shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  ghcr.io/gitguardian/wolfi/static:latest | jq -r .payload | base64 -d | jq .predicate
+```

--- a/images/static/prod.yaml
+++ b/images/static/prod.yaml
@@ -1,0 +1,12 @@
+include: images/apko.yaml
+
+contents:
+  packages:
+    - ca-certificates-bundle
+    - tzdata
+    - wolfi-baselayout
+
+annotations:
+  org.opencontainers.image.title: 'static'
+  org.opencontainers.image.description: 'Minimal Wolfi-based runtime for statically-linked binaries (Go, Rust, C)'
+  org.opencontainers.image.source: 'https://github.com/GitGuardian/wolfi/tree/main/images/static'


### PR DESCRIPTION
Add a `static` image: a minimal, distroless-style runtime for statically-linked binaries (Go, Rust, C/C++). It contains only ca-certificates-bundle, tzdata and wolfi-baselayout — no shell, no package manager and no libc — and runs as the non-root user (uid/gid 65532) inherited from images/apko.yaml.

- images/static/prod.yaml: package set + OCI annotations (no entrypoint; base image)
- images/static/README.md: usage snippet + provenance / signature / SBOM verification
- .github/workflows/static.yaml: weekday rebuild, single latest/prod target
- README.md: registry table entry (kept alphabetical)