### PR TITLE
feat(loki): add 3.7.6 to the published tag matrix

### DIFF
--- a/.github/workflows/loki.yaml
+++ b/.github/workflows/loki.yaml
@@ -29,7 +29,7 @@ jobs:
   publish:
     strategy:
       matrix:
-        version: [latest, "3.7", "3.7.3", "3.7.2", "3.7.1", "3.6.10", "3.6.8"]
+        version: [latest, "3.7", "3.7.6", "3.7.3", "3.7.2", "3.7.1", "3.6.10", "3.6.8"]
         variant: [prod, shell]
     name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || '' }}
     uses: './.github/workflows/release.yaml'

--- a/images/loki/README.md
+++ b/images/loki/README.md
@@ -10,6 +10,10 @@ This image contains the loki application for log aggregation. loki can be used t
 | latest-shell | ghcr.io/gitguardian/wolfi/loki:latest-shell |
 | 3.7          | ghcr.io/gitguardian/wolfi/loki:3.7          |
 | 3.7-shell    | ghcr.io/gitguardian/wolfi/loki:3.7-shell    |
+| 3.7.6        | ghcr.io/gitguardian/wolfi/loki:3.7.6        |
+| 3.7.6-shell  | ghcr.io/gitguardian/wolfi/loki:3.7.6-shell  |
+| 3.7.3        | ghcr.io/gitguardian/wolfi/loki:3.7.3        |
+| 3.7.3-shell  | ghcr.io/gitguardian/wolfi/loki:3.7.3-shell  |
 | 3.7.2        | ghcr.io/gitguardian/wolfi/loki:3.7.2        |
 | 3.7.2-shell  | ghcr.io/gitguardian/wolfi/loki:3.7.2-shell  |
 | 3.7.1        | ghcr.io/gitguardian/wolfi/loki:3.7.1        |


### PR DESCRIPTION
CVE-2026-56852 (High, golang.org/x/text infinite loop) and CVE-2026-73500 (High, vendored etcd tlsListener) both affect loki-3.7 3.7.3-r3, which is what the pinned 3.7.3 tag resolves to. They are fixed in 3.7.4-r1 and 3.7.6-r2 respectively, and the package feed already carries 3.7.6-r3 -- the floating 3.7 tag built on 2026-08-21 scans clean on every severity. Only the pinned tag was missing, so consumers that pin a patch version had no way to pick the fix up.

Also completes the version table, which still stopped at 3.7.2 even though 3.7.3 was added to the matrix in #63.